### PR TITLE
Epartner name fix

### DIFF
--- a/bw4t/bw4t-scenario-editor/src/main/java/nl/tudelft/bw4t/scenariogui/epartner/controller/EpartnerController.java
+++ b/bw4t/bw4t-scenario-editor/src/main/java/nl/tudelft/bw4t/scenariogui/epartner/controller/EpartnerController.java
@@ -112,7 +112,7 @@ public class EpartnerController {
 	 * @param epf is the Epartnerframe the values are taken from.
 	 */
 	public void updateConfig(EpartnerFrame epf) {
-		epConfig.setEpartnerName(epf.getName());
+		epConfig.setEpartnerName(epf.getEpartnerName());
 		epConfig.setEpartnerAmount(epf.getEpartnerAmount());
 		epConfig.setGps(epf.getGPS());
 		epConfig.setForgetMeNot(epf.getForgetMeNot());


### PR DESCRIPTION
When something in the epartner store has changed, epartner name doesn't change to 'frame#' anymore
